### PR TITLE
Mining Calculation Commands

### DIFF
--- a/cogs/utilities.py
+++ b/cogs/utilities.py
@@ -509,7 +509,7 @@ Very Low Priority (144 blocks+/1d+) = {vlow} sat/vbyte
 	@commands.command()
 	async def mine(self, ctx, *args):
 		if len(args) != 4:
-			await ctx.send("The !mine command requires four arguments: `period` (block/hour/day/week/month/year), `sats/KWh` (electricity cost), `mining watts` (eg: 3247 for an S19j XP), and `joules per terahash` (eg: 21.5 for an S19j XP).")
+			await ctx.send("The !mine command requires four arguments: `period` (block/hour/day/week/month/year), `sats/kWh` (electricity cost), `mining watts` (eg: 3247 for an S19j XP), and `joules per terahash` (eg: 21.5 for an S19j XP).")
 			return
 
 		period = args[0].lower()
@@ -580,9 +580,9 @@ Very Low Priority (144 blocks+/1d+) = {vlow} sat/vbyte
 		net_income = gross_income - electricity_cost
 
 		if watts >= 1000:
-			energy_string = '{} kW'.format(floatFormat(round(watts / 1000, 2)))
+			energy_string = '{} kWh'.format(floatFormat(round(watts / 1000, 2)))
 		else:
-			energy_string = "{:,.0f} W".format(watts)
+			energy_string = "{:,.0f} Wh".format(watts)
 
 		net_income = '{:,.8f}'.format(net_income)
 		hash_rate = floatFormat(round(hash_rate, 4))

--- a/cogs/utilities.py
+++ b/cogs/utilities.py
@@ -470,5 +470,36 @@ Very Low Priority (144 blocks+/1d+) = {vlow} sat/vbyte
 			'{:,.4f}'.format(average_reward))
 		ctx.send(message_string)
 
+	@commands.command()
+	async def solomine(self, ctx, *args):
+		solo_hash_rate = args[0]
+		if not solo_hash_rate {
+			await ctx.send("Please specify a hashrate in TH/s.")
+			return
+		}
+
+		api = "https://blockchain.info/q/hashrate"
+		r = requests.get(api)
+		network_hashrate = (Decimal(r.text) / 1000)
+
+		hash_share = solo_hash_rate / network_hashrate
+		blocks = 1 / hash_share
+		days = blocks / 6 / 24
+
+		if days > 365.2425 {
+			time_description = string.format("{} years", '{:,.2f}'.format(days / 365.2425))
+		} else {
+			time_description = string.format("{} days", '{:,.2f}'.format(days))
+		}
+
+		message_string = string.format(
+			"With a hashrate of {} TH/s, and a network hashrate of {}, it would take on average {} blocks, or {} to mine a block.",
+			solo_hash_rate,
+			network_hashrate,
+			blocks,
+			time_description)
+
+		ctx.send(message_string)
+
 async def setup(bot):
 	await bot.add_cog(Utilities(bot))

--- a/cogs/utilities.py
+++ b/cogs/utilities.py
@@ -9,6 +9,7 @@ from captcha.image import ImageCaptcha
 import math
 import hashlib
 import datetime
+from decimal import Decimal
 import time
 import ipc
 
@@ -437,6 +438,37 @@ Very Low Priority (144 blocks+/1d+) = {vlow} sat/vbyte
 	async def halvening(self, ctx, *args):
 		await Utilities(self).halving(self, ctx, args)
 
+	@commands.command()
+	async def hashrate(self, ctx, *args):
+		api = "https://blockchain.info/q/hashrate"
+		r = requests.get(api)
+		network_hashrate = (Decimal(r.text) / 1000)
+		message_string = string.format(
+			"The current network hashrate is {} TH/s."
+			'{:,.2f}'.format(network_hashrate))
+		ctx.send(message_string)
+
+	@commands.command()
+	async def reward(self, ctx, *args):
+		period = args[0]
+		if not args[0] {
+			period = "1m"
+		}
+
+		api = string.format("https://mempool.space/api/v1/mining/blocks/rewards/{}", period)
+		r = requests.get(api)
+		try:
+			data = json.loads(r.text)
+		except:
+			await ctx.send("Invalid average reward period; allowed values are (24h, 3d, 1w, 1m, 3m, 6m, 1y, 2y, 3y).")
+			return
+
+		average_reward = Decimal(data[0]["avgRewards"]) / 100000000
+		message_string = string.format(
+			"The {} average block reward is {} BTC.",
+			period,
+			'{:,.4f}'.format(average_reward))
+		ctx.send(message_string)
 
 async def setup(bot):
 	await bot.add_cog(Utilities(bot))

--- a/cogs/utilities.py
+++ b/cogs/utilities.py
@@ -465,7 +465,7 @@ Very Low Priority (144 blocks+/1d+) = {vlow} sat/vbyte
 			await ctx.send("Failed to get the average reward.")
 			return
 
-		message_string = "The {} average block reward is {} BTC.".format(period, '{:,.8f}'.format(average_reward))
+		message_string = "The {} average block reward is {} BTC.".format(period, floatFormat(round(average_reward, 8)))
 		await ctx.send(message_string)
 
 	@commands.command()
@@ -584,10 +584,10 @@ Very Low Priority (144 blocks+/1d+) = {vlow} sat/vbyte
 		else:
 			energy_string = "{:,.0f} Wh".format(watts)
 
-		net_income = '{:,.8f}'.format(net_income)
 		hash_rate = floatFormat(round(hash_rate, 4))
-		gross_income = '{:,.8f}'.format(gross_income)
-		electricity_cost = '{:,.8f}'.format(electricity_cost)
+		net_income = floatFormat(round(net_income, 8))
+		gross_income = floatFormat(round(gross_income, 8))
+		electricity_cost = floatFormat(round(electricity_cost, 8))
 		if sats_kwh == 0.0:
 			message_string = "Your hashrate is {} TH/s, and your expected income each {} is {} BTC, using {}.".format(
 				hash_rate,


### PR DESCRIPTION
# Mining Calculation Commands

This pull request adds the following 4 commands to the bot:
- **!hashrate**
  Gets the current network hashrate from the `blockchain.info` API and displays it in TH/S format to 2dp, with no trailing zero decimal places.
- **!reward**
  Gets the average block reward for the specified period, displaying it in BTC to 8dp (no trailing 0 decimal places). The default period is `1m` (one month), with available options: `24h, 3d, 1w, 1m, 3m, 6m, 1y, 2y, 3y`. An invalid specified period prompts an error message which lists these options.
- **!solomine [HASHRATE TH/S]**
  Calculates the average number of blocks it would take a solo miner with the specified hashrate would find a block, given the current network hashrate.
  
  This expected time is also displayed as either a day or year value, depending on whether the number of days is `>= 365.2425` (the mean number of days in a year).
  
  Day/year and block values are to 2dp, the solo mine hashrate is repeated back without rounding, and the network hashrate is displayed to 4dp. All values have trailing 0 decimal places trimmed.
- **!mine [PERIOD] [SATS/KWH] [W] [J/TH]**
  Calculates the hashrate, energy usage, and average gross income, electricity cost, and net income for a specified period (valid options are: block, hour, day, week, month (30d), year), price in satoshi per kWh, watts of mining capacity, and hashing efficiency in J/TH, given the current 1m average block reward and network hash rate.
  
  If the energy cost is 0, the output skips the energy cost and gross income values.

  If the energy usage over a period is `>= 1000 wh`, the value is displayed in kWh, to 2dp. Otherwise, it is displayed in wh, no decimal places. The hashrate is displayed to 4dp, and all monetary values diplayed in BTC to 8dp. All values have trailing 0 decimal places trimmed.