### PR TITLE
Add estimation method for next block timing

### DIFF
--- a/BitcoinAPI.py
+++ b/BitcoinAPI.py
@@ -1,3 +1,4 @@
+from _pydecimal import Decimal
 from typing import Tuple
 
 import requests
@@ -8,8 +9,8 @@ import discord
 TIMEOUT = 10
 coincap_rates = "https://api.coincap.io/v2/rates/"
 coincap_btc = "https://api.coincap.io/v2/assets/bitcoin"
-
-
+MEMPOOL_DIFFICULTY = "https://mempool.space/api/v1/mining/difficulty-adjustments/1m"
+MEMPOOL_HASHRATE = "https://mempool.space/api/v1/mining/hashrate/current"
 def get_current_price() -> tuple[None, str] | tuple[float, None]:
     """
     Retrieve the current price of Bitcoin from the CoinCap API.
@@ -121,6 +122,29 @@ def get_bitcoin_ath(currency) -> tuple[None, None, str] | tuple[str, float, None
         error = f"Failed to fetch price with error"
         return None, None, error
     return bitcoin_ath, bitcoin_ath_float, error
+
+
+def get_mempool_difficulty() -> tuple[None, None, str] | tuple[int, float, None]:
+    try:
+        response = requests.get(MEMPOOL_DIFFICULTY, timeout=TIMEOUT)
+        response.raise_for_status()
+        difficulty_data = response.json()[0]
+    except requests.RequestException as _:
+        error = f"Failed to fetch mempool difficulty with error"
+        return None, None, error
+    return difficulty_data[2], difficulty_data[3], None
+
+
+def get_hashrate() -> tuple[None, str] | tuple[Decimal, None]:
+
+    try:
+        response = requests.get(MEMPOOL_HASHRATE)
+        response.raise_for_status()
+        data = response.json()
+    except requests.RequestException as _:
+        error = f"Failed to fetch mempool hashrate with error"
+        return None, error
+    return Decimal(data["currentHashrate"]), None
 
 
 def get_chart(name, timespan="10weeks"):

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -160,6 +160,28 @@ class General(commands.Cog):
 		message_string = f"**Bitcoin ATH** is currently **{ath_str}**"
 		await ctx.send(message_string)
 
+	@commands.command()
+	async def difficulty(self, ctx, *args):
+		difficulty, _, error = api.get_mempool_difficulty()
+		if error:
+			return await ctx.send("Failed to fetch mempool difficulty")
+		await ctx.send(f"**Current difficulty** is **{difficulty}**")
+
+	@commands.command()
+	async def block(self, ctx, *args):
+		available_commands = ["next"]
+		if len(args) == 0 or args[0] not in available_commands:
+			return await ctx.send(f"Usage: !block <argument>, available arguments: {', '.join(available_commands)}")
+		if args[0] == "next":
+			difficulty, _, error = api.get_mempool_difficulty()
+			if error:
+				return await ctx.send(error)
+			hashrate, error = api.get_hashrate()
+			if error:
+				return await ctx.send(error)
+			next_block = (difficulty * 2**32) / int(hashrate)
+			await ctx.send(f"**Next block is estimated to be mined in {int(next_block)}s**")
+
 	@staticmethod
 	def get_fact():
 		while True:

--- a/cogs/utilities.py
+++ b/cogs/utilities.py
@@ -14,6 +14,7 @@ from decimal import Decimal
 import time
 import ipc
 from constants import ITEM_DICT, write_items
+import BitcoinAPI
 
 
 class Utilities(commands.Cog):
@@ -519,16 +520,14 @@ Very Low Priority (144 blocks+/1d+) = {vlow} sat/vbyte
 	async def halvening(self, ctx, *args):
 		await Utilities(self).halving(self, ctx, args)
 
-	def get_hashrate(self):
-		api = "https://mempool.space/api/v1/mining/hashrate/current"
-		r = requests.get(api)
-		data = json.loads(r.text)
-		return Decimal(data["currentHashrate"])
-
 	@commands.command()
 	async def hashrate(self, ctx, *args):
-		#                                                   kilo   mega   giga   tera   peta   exa
-		network_hashrate = Utilities(self).get_hashrate() / 1000 / 1000 / 1000 / 1000 / 1000 / 1000
+
+		network_hashrate, error = BitcoinAPI.get_hashrate()
+		if error:
+			return await ctx.send("Failed to get the hashrate.")
+		#                            		  kilo   mega   giga   tera   peta   exa
+		network_hashrate = network_hashrate / 1000 / 1000 / 1000 / 1000 / 1000 / 1000
 		message_string = "The current network hashrate is {} EH/s.".format(floatFormat(round(network_hashrate, 2)))
 		await ctx.send(message_string)
 


### PR DESCRIPTION
New Commands:
- !block <next>: Provides the estimated time until the next block is mined.
- !difficulty: Displays the current mempool difficulty.

API Integration:
- Added functionality to retrieve the current hashrate and difficulty from the API.
- Updated the !hashrate command to use API data instead of querying an endpoint itself.